### PR TITLE
feat : implement Modal Component

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   experimental: {
     reactMode: 'concurrent',
   },

--- a/src/components/App/AppFooter/FooterContent/FooterContent.tsx
+++ b/src/components/App/AppFooter/FooterContent/FooterContent.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { useNavigation } from '@/util/hooks/useNavigation';
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
+import { useModalContext } from '@/components/UI/Modal/Modal.hooks';
 
 export type NavItemName = IconName;
 export type NavItemPath = `/${string}`;
@@ -30,9 +31,6 @@ export const NavIcon = ({ name, directionPath, ...props }: NavIconProps) => {
   const handleRoute = () => {
     navigateTo(directionPath);
   };
-
-  console.log(directionPath);
-  console.log(getCurrentPath());
 
   const totalColor =
     getCurrentPath() === directionPath ? theme.color.nav.active : theme.color.nav.disabled;

--- a/src/components/UI/Modal/Impls/BasicModal.styles.ts
+++ b/src/components/UI/Modal/Impls/BasicModal.styles.ts
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+import { Flex } from '@/components/UI/FlexBox';
+
+export const Root = styled.div`
+  width: 28.1rem;
+  height: 20.9rem;
+`;
+
+export const Container = styled(Flex)<{ visible: boolean }>`
+  background: ${({ theme }) => theme.color.background.default};
+  border-radius: 20px;
+  padding: 1.8rem;
+
+  transform: ${({ visible }) => (visible ? 'translateY(0)' : 'translateY(70rem)')};
+  transition: transform 400ms;
+`;
+
+export const Wrapper = styled(Flex)`
+  width: 100%;
+  & header {
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 140%;
+    margin-top: 2.6rem;
+    text-align: center;
+    width: 100%;
+  }
+
+  & main {
+    margin-top: 4rem;
+    width: 100%;
+  }
+
+  & footer {
+    margin-top: 4rem;
+    width: 100%;
+  }
+`;
+
+export const ModalButton = styled(Flex)`
+  background: ${({ theme }) => theme.color.background.darker};
+  width: 100%;
+  height: 5.1rem;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1.6rem;
+  line-height: 140%;
+  color: ${({ theme }) => theme.color.text.g2};
+  border-radius: 13px;
+  border: none;
+
+  &:hover {
+    background: ${({ theme }) => theme.color.nav.active};
+  }
+`;

--- a/src/components/UI/Modal/Impls/BasicModal.tsx
+++ b/src/components/UI/Modal/Impls/BasicModal.tsx
@@ -1,0 +1,22 @@
+import * as S from './BasicModal.styles';
+import { DefaultModalProps } from '@/components/UI/Modal/Modal.types';
+
+export type BasicModalProps = {
+  title: string;
+} & DefaultModalProps;
+
+export const BasicModal = ({ visible, close, title = '테스트' }: BasicModalProps) => {
+  return (
+    <S.Root>
+      <S.Container flex={'rowCenter'} visible={visible}>
+        <S.Wrapper flex={'columnStart'}>
+          <header>안녕하세요 모달입니다.</header>
+          <main>나는 모달 바디</main>
+          <footer>나는 모달 푸터임 ㅋㅋ</footer>
+        </S.Wrapper>
+      </S.Container>
+    </S.Root>
+  );
+};
+
+export default BasicModal;

--- a/src/components/UI/Modal/Impls/PreparingServiceModal.tsx
+++ b/src/components/UI/Modal/Impls/PreparingServiceModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import * as S from '@/components/UI/Modal/Impls/BasicModal.styles';
+import { DefaultModalProps } from '@/components/UI/Modal/Modal.types';
+
+export type PreParingModalProps = {} & DefaultModalProps;
+
+export const PreParingServiceModal = ({ visible, close }: PreParingModalProps) => {
+  return (
+    <S.Root>
+      <S.Container flex={'rowCenter'} visible={visible}>
+        <S.Wrapper flex={'columnStart'}>
+          <header>
+            앗, 열심히 준비하고 있어요.
+            <br />
+            잠시만 기다려주세요!
+          </header>
+          <footer>
+            <S.ModalButton as={'button'} flex={'rowCenter'} onClick={close}>
+              확인
+            </S.ModalButton>
+          </footer>
+        </S.Wrapper>
+      </S.Container>
+    </S.Root>
+  );
+};
+
+export default PreParingServiceModal;

--- a/src/components/UI/Modal/Impls/index.ts
+++ b/src/components/UI/Modal/Impls/index.ts
@@ -1,0 +1,2 @@
+export * from './BasicModal.styles';
+export * from './BasicModal';

--- a/src/components/UI/Modal/Modal.Container.tsx
+++ b/src/components/UI/Modal/Modal.Container.tsx
@@ -1,0 +1,135 @@
+import React, { cloneElement, useEffect } from 'react';
+import {
+  DynamicImporter,
+  ModalRegistry,
+  OpenModalPayloadWithId,
+  OverlayOptions,
+} from '@/components/UI/Modal/Modal.types';
+import styled from '@emotion/styled';
+import { useModalContext } from '@/components/UI/Modal/Modal.hooks';
+
+interface ModalOverlayProps extends OverlayOptions {
+  closeSelf: () => void;
+  children: React.ReactElement;
+}
+
+export const ModalOverlay = ({
+  className = '',
+  closeDelay = 0,
+  closeOnOverlayClick = true,
+  dim = true,
+  preventScroll = true,
+  children,
+  closeSelf,
+}: ModalOverlayProps) => {
+  // animated close
+  const [visible, setVisible] = React.useState(false);
+
+  useEffect(() => {
+    window.requestAnimationFrame(() => setVisible(true));
+  }, []);
+
+  const delayedClose = () => {
+    setVisible(false);
+    setTimeout(closeSelf, closeDelay);
+  };
+
+  const onClick = (e: React.MouseEvent) => {
+    if (!closeOnOverlayClick) return;
+    if (e.target === e.currentTarget) {
+      delayedClose();
+    }
+  };
+
+  useEffect(() => {
+    if (preventScroll) {
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = 'initial';
+      };
+    }
+  }, []);
+
+  return (
+    <OverlayRoot dim={dim} onClick={onClick}>
+      {cloneElement(children, { close: delayedClose, visible })}
+    </OverlayRoot>
+  );
+};
+
+const OverlayRoot = styled.div<{ dim: boolean }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+  ${({ theme, dim }) => {
+    return `
+      ${dim && 'background: rgba(22, 29, 36, 0.4);'}
+    '}
+    `;
+  }}
+`;
+
+type OpenedModalProps<R extends ModalRegistry> = OpenModalPayloadWithId<R, keyof R> & {
+  importer: DynamicImporter;
+};
+export const OpenedModal = <R extends ModalRegistry>({
+  importer,
+  type,
+  id,
+  props,
+  overlayOptions,
+  events,
+}: OpenedModalProps<R>) => {
+  const { closeModal } = useModalContext();
+  const [Component, setComponent] = React.useState<React.ComponentType>();
+
+  // asynchronously import modal file: for reduce bundle size.
+  // this may trigger initial openModal could be delayed.
+  // if you don't want to be delayed, use usePreloadModal hook
+  useEffect(() => {
+    importer().then((modal) => {
+      setComponent(() => modal.default);
+    });
+  }, [type]);
+
+  const closeModalBySelf = () => {
+    events?.onClose?.();
+    closeModal({ id });
+  };
+
+  if (!Component) return null;
+  return (
+    <ModalOverlay {...overlayOptions} closeSelf={closeModalBySelf}>
+      <Component {...props} />
+    </ModalOverlay>
+  );
+};
+
+interface ModalContainerProps<R extends ModalRegistry> {
+  registry: R;
+  openedModals: OpenModalPayloadWithId<R, keyof R>[];
+}
+export const ModalContainer = <R extends ModalRegistry>({
+  registry,
+  openedModals,
+}: ModalContainerProps<R>) => {
+  return (
+    <div id="modal-root">
+      {openedModals.map((modalState) => {
+        const props: OpenedModalProps<typeof registry> = {
+          importer: registry[modalState.type],
+          ...modalState,
+        };
+        return <OpenedModal key={modalState.id} {...props} />;
+      })}
+    </div>
+  );
+};
+
+export default ModalContainer;

--- a/src/components/UI/Modal/Modal.Context.tsx
+++ b/src/components/UI/Modal/Modal.Context.tsx
@@ -1,0 +1,57 @@
+import {
+  CloseModalPayload,
+  ModalRegistry,
+  OpenModalPayload,
+  OpenModalPayloadWithId,
+  OverlayOptions,
+} from '@/components/UI/Modal/Modal.types';
+import React, { createContext, PropsWithChildren, useContext } from 'react';
+import { useModalReducer } from '@/components/UI/Modal/Modal.reducer';
+import ModalContainer from '@/components/UI/Modal/Modal.Container';
+
+export type ModalContextType<R extends ModalRegistry> = {
+  openedModals: OpenModalPayload<R, keyof R>[];
+  openModal: <T extends keyof R>(
+    payload: OpenModalPayload<R, T>
+  ) => OpenModalPayloadWithId<R, keyof R>;
+  closeModal: (payload: CloseModalPayload) => { id: string };
+  closeAllModal: () => void;
+};
+
+export const createModalContext = <R extends ModalRegistry>() =>
+  createContext<ModalContextType<R>>({
+    openedModals: [],
+    openModal: (payload) => ({ ...payload, id: '' }),
+    closeModal: (payload: CloseModalPayload) => {
+      return { id: '' };
+    },
+    closeAllModal: () => {
+      return;
+    },
+  });
+
+export const ModalContext = createModalContext();
+
+export type ModalProviderProps<R extends ModalRegistry> = {
+  registry: R;
+  defaultOverlayOptions?: { default?: Partial<OverlayOptions> } & {
+    [key in keyof R]?: Partial<OverlayOptions>;
+  };
+};
+
+export const ModalProvider = <R extends ModalRegistry>({
+  registry,
+  defaultOverlayOptions,
+  children,
+}: PropsWithChildren<ModalProviderProps<R>>) => {
+  const { openedModals, ...actions } = useModalReducer<R>(defaultOverlayOptions);
+
+  const TypedModalContext = ModalContext as React.Context<ModalContextType<R>>;
+
+  return (
+    <TypedModalContext.Provider value={{ openedModals, ...actions }}>
+      {children}
+      <ModalContainer registry={registry} openedModals={openedModals} />
+    </TypedModalContext.Provider>
+  );
+};

--- a/src/components/UI/Modal/Modal.hooks.ts
+++ b/src/components/UI/Modal/Modal.hooks.ts
@@ -1,0 +1,12 @@
+import {
+  createModalContext,
+  ModalContext,
+  ModalContextType,
+} from '@/components/UI/Modal/Modal.Context';
+import React, { useContext } from 'react';
+import { ModalRegistry } from '@/components/UI/Modal/Modal.types';
+
+export const useModalContext = <R extends ModalRegistry>() => {
+  const context = useContext(ModalContext as React.Context<ModalContextType<R>>);
+  return context;
+};

--- a/src/components/UI/Modal/Modal.reducer.ts
+++ b/src/components/UI/Modal/Modal.reducer.ts
@@ -1,0 +1,85 @@
+import {
+  CloseModalPayload,
+  ModalRegistry,
+  OpenModalPayload,
+  OpenModalPayloadWithId,
+  OverlayOptions,
+} from '@/components/UI/Modal/Modal.types';
+import React from 'react';
+import { getRandomHex } from '@/util';
+import { reducer } from 'next/dist/client/components/router-reducer/router-reducer';
+
+export const ACTION_TYPE_MODAL_CLOSE = 'CLOSE';
+export const ACTION_TYPE_MODAL_OPEN = 'OPEN';
+export const ACTION_TYPE_MODAL_CLOSE_ALL = 'CLOSE_ALL';
+
+export const useModalReducer = <R extends ModalRegistry>(
+  defaultOverlayOptions?: { default?: Partial<OverlayOptions> } & {
+    [key in keyof R]?: Partial<OverlayOptions>;
+  }
+) => {
+  const modalReducer = (state: OpenModalPayloadWithId<R, keyof R>[], action: ModalActions) => {
+    switch (action.type) {
+      case ACTION_TYPE_MODAL_OPEN:
+        return [...state, action.payload];
+      case ACTION_TYPE_MODAL_CLOSE:
+        return state.filter((modal) => modal.id !== action.payload.id);
+      case ACTION_TYPE_MODAL_CLOSE_ALL:
+        return [];
+    }
+  };
+
+  const [openedModals, dispatch] = React.useReducer(
+    modalReducer,
+    [] as OpenModalPayloadWithId<R, keyof R>[]
+  );
+
+  const openModal = (externalPayload: OpenModalPayload<R, keyof R>) => {
+    const modalId = getRandomHex();
+
+    return {
+      type: ACTION_TYPE_MODAL_OPEN as 'OPEN',
+      payload: {
+        type: externalPayload.type,
+        props: externalPayload.props,
+        overlayOptions: Object.assign(
+          {},
+          defaultOverlayOptions?.default,
+          defaultOverlayOptions?.[externalPayload.type],
+          externalPayload.overlayOptions
+        ),
+        events: externalPayload.events,
+        id: modalId,
+      } as OpenModalPayloadWithId<R, keyof R>,
+    };
+  };
+
+  const closeModal = (payload: CloseModalPayload) => {
+    return { type: ACTION_TYPE_MODAL_CLOSE as 'CLOSE', payload };
+  };
+
+  const closeAllModal = () => {
+    return { type: ACTION_TYPE_MODAL_CLOSE_ALL as 'CLOSE_ALL' };
+  };
+
+  type ModalActions = ReturnType<typeof openModal | typeof closeModal | typeof closeAllModal>;
+
+  const WrappedActions = {
+    openModal: (payload: OpenModalPayload<R, keyof R>) => {
+      const action = openModal(payload);
+      dispatch(action);
+      return action.payload;
+    },
+    closeModal: (payload: CloseModalPayload) => {
+      const action = closeModal(payload);
+      dispatch(action);
+      return { id: action.payload.id };
+    },
+    closeAllModal: () => {
+      const action = closeAllModal();
+      dispatch(action);
+    },
+  };
+
+  return { openedModals, ...WrappedActions };
+};

--- a/src/components/UI/Modal/Modal.types.ts
+++ b/src/components/UI/Modal/Modal.types.ts
@@ -1,0 +1,65 @@
+export type DynamicImporter = () => Promise<{ default: React.ComponentType<any> }>;
+
+export interface ModalRegistry {
+  [key: string]: DynamicImporter;
+}
+
+type Await<T> = T extends PromiseLike<infer U> ? U : T;
+type EmptyObject = Record<string, never>;
+
+export type ModalProps<TImporter extends DynamicImporter> = React.ComponentProps<
+  Await<ReturnType<TImporter>>['default']
+>;
+
+export type DefaultModalProps = {
+  close(): void;
+  visible: boolean;
+};
+
+export type ModalOwnProps<TImporter extends DynamicImporter> = Omit<
+  ModalProps<TImporter>,
+  keyof DefaultModalProps
+>;
+
+// from @type-challenges/utils
+type Equals<X, Y> = (() => Y extends X ? 1 : 2) extends () => X extends Y ? 1 : 2 ? true : false;
+
+export type OpenModalPayload<R extends ModalRegistry, Rkey extends keyof R> = Equals<
+  ModalOwnProps<R[Rkey]>,
+  EmptyObject
+> extends true
+  ? {
+      type: Rkey;
+      props?: ModalOwnProps<R[Rkey]>;
+      overlayOptions?: OverlayOptions;
+      events?: ModalEvents;
+    }
+  : {
+      type: Rkey;
+      props: ModalOwnProps<R[Rkey]>;
+      overlayOptions?: OverlayOptions;
+      events?: ModalEvents;
+    };
+
+export type OpenModalPayloadWithId<
+  R extends ModalRegistry,
+  Rkey extends keyof R
+> = OpenModalPayload<R, Rkey> & {
+  id: string;
+};
+
+export type CloseModalPayload = {
+  id: string;
+};
+
+export interface OverlayOptions {
+  className?: string;
+  closeDelay?: number;
+  closeOnOverlayClick?: boolean;
+  dim?: boolean;
+  preventScroll?: boolean;
+}
+
+export interface ModalEvents {
+  onClose?(): void;
+}

--- a/src/components/UI/Modal/ModalRegistry.ts
+++ b/src/components/UI/Modal/ModalRegistry.ts
@@ -1,0 +1,4 @@
+export const ModalRegistry = {
+  Basic: () => import('./Impls/BasicModal'),
+  PreparingService: () => import('./Impls/PreparingServiceModal'),
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,18 +7,25 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
 import React from 'react';
 import { RecoilRoot } from 'recoil';
+import { ModalProvider } from '@/components/UI/Modal/Modal.Context';
+import { ModalRegistry } from '@/components/UI/Modal/ModalRegistry';
 
 export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient());
+
   return (
     <>
       <RecoilRoot>
         <QueryClientProvider client={queryClient}>
           <Hydrate state={pageProps.dehydratedState}>
             <ThemeProvider theme={DEFAULT_THEME}>
-              <Layout>
-                <Component {...pageProps} />
-              </Layout>
+              <ModalProvider
+                registry={ModalRegistry}
+                defaultOverlayOptions={{ default: { closeDelay: 500 } }}>
+                <Layout>
+                  <Component {...pageProps} />
+                </Layout>
+              </ModalProvider>
             </ThemeProvider>
           </Hydrate>
           <ReactQueryDevtools />

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -1,6 +1,31 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
+import { useModalContext } from '@/components/UI/Modal/Modal.hooks';
+import { useNavigation } from '@/util/hooks/useNavigation';
 
 const SettingPage = () => {
+  const { openModal } = useModalContext();
+  const { getCurrentPath, navigateTo } = useNavigation();
+  const handleOpenModal = () => {
+    openModal({
+      type: 'PreparingService',
+      props: {},
+      events: {
+        onClose: () => {
+          navigateTo('/');
+        },
+      },
+    });
+  };
+  console.log('렌더링 세팅 페이지');
+
+  useEffect(() => {
+    console.log('이펙트 실행');
+    if (getCurrentPath() === '/setting') handleOpenModal();
+    return () => {
+      console.log('페이지 언마운트 세팅');
+    };
+  }, []);
+
   return <div></div>;
 };
 

--- a/src/util/Number.ts
+++ b/src/util/Number.ts
@@ -1,0 +1,6 @@
+export const getRandomHex = (): string => {
+  const hex = Math.floor(Math.random() * 0xffffffff)
+    .toString(16)
+    .padStart(8, '0');
+  return hex;
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from './Error';
 export * from './Fetch';
+export * from './Number';


### PR DESCRIPTION
Context Provider를 통해 전역적으로 사용할 수 있는 모달 컴포넌트를 구현합니다.

Modal의 열고 닫음에 대한 상태값을 각 컴포넌트에서 관리하는 방식의 지저분함과 props drilling 등의 문제점이 발생할 수 있는 것, 동일한 close 혹은 open 핸들러를 중복으로 사용하여 모달 컴포넌트 구조가 너무 다양화 되버릴 가능성이 있는 것을 통일하고, 동적 Import를 활용하여 번들링 사이즈를 줄이는 방식으로 구현했습니다.

새로운 모달 컴포넌트가 필요할 때,
src/UI/Modal/impls 에 구현하고, 동일 폴더의 ModalRegistry 에서 동적 import 선언만 해놓으면 모달을 사용하고 싶은 어떤 컴포넌트에서든지 useModalContext()를 통해 사용할 수 있습니다.