### PR TITLE
LM-88 feedback result header

### DIFF
--- a/src/components/App/AppHeader/HeaderContent/HeaderContent.tsx
+++ b/src/components/App/AppHeader/HeaderContent/HeaderContent.tsx
@@ -5,6 +5,7 @@ import { BackwardContainer } from './HeaderContent.styles';
 import { SVGIcon } from '@/components/UI/SVGIcon';
 import { useNavigation } from '@/util/hooks/useNavigation';
 import { HeaderBackArrow } from '@/components/UI/SVGIcon/templates';
+import { RecordProcessState } from '@/components/Domain/Feedback/FeedbackRecord.hooks';
 
 export const HeaderContent = () => {
   const { headerContent } = useHeader();
@@ -38,8 +39,18 @@ export const HeaderContent = () => {
 
 export const HeaderBackward = () => {
   const { router } = useNavigation();
+  const recordQueryString = router.query?.record as RecordProcessState;
+
   const handlePrevPage = () => {
+    if (recordQueryString === 'success'){
+      router.push({
+        pathname: '/',
+        query: {}
+      });
+      return console.log(router.asPath)
+    }
     router.back();
+    return console.log(router.asPath)
   };
 
   return (


### PR DESCRIPTION
작업요약
- result page 마지막의 결과 창에서만 back icon 클릭시 홈으로 가도록 경로 설정

작업상세
- 해당 icon을 관리하는 headercomponent에서 query 값에 따라 마지막 결과창인 success일때만 home으로 가게 경로를 설정해줌.

경로 설정이 옳게 되어 추가 자료는 없습니다.

* 위 작업 테스트 중 다른 버그를 발견했습니다 
 - 피드백을 받은 후 시간이 얼마 지나지 않아 같은 경로로 피드백 받기로 들어가면 녹음 화면 x -> 아까받은 피드백 화면 창이 나옵니다.