### PR TITLE
LM-163

### DIFF
--- a/src/components/Domain/Ranking/Ranking.hooks.ts
+++ b/src/components/Domain/Ranking/Ranking.hooks.ts
@@ -1,12 +1,25 @@
+import React from "react";
 import { useNavigation } from "@/util/hooks/useNavigation";
 import { useCallback, useEffect } from "react";
 import { useRecoilState } from "recoil";
 import { headerContentState } from '@/states/state.header';
-import {
-    RankingHeader,
-    RankingDescription,
-  } from '@/components/App/AppHeader/HeaderContent/HeaderContentImpls/RankingHeader';
+import { RankingHeader, RankingDescription } from '@/components/App/AppHeader/HeaderContent/HeaderContentImpls/RankingHeader';
+import { useQuery } from "@tanstack/react-query";
+import { RankingControllerApi } from "@/util/Api";
 
+export const RANKING_QUERY_KEY = 'ranking';
+
+export const useGetRankingQuery = () => {
+    const { data, status } = useQuery({
+        queryKey:[RANKING_QUERY_KEY],
+        queryFn: async () => {
+            const api = new RankingControllerApi();
+            return await api.getRanking();
+        },
+        enabled:true,
+    });
+    return {data, status};
+};
 
 export const useSettingHeader = () => {
     const [headerContent, setHeaderContent] = useRecoilState(headerContentState);
@@ -25,6 +38,4 @@ export const useSettingHeader = () => {
     useEffect(() => {
         initializeHeaderContent();
     }, []);
-
-
-}
+};

--- a/src/components/Domain/Ranking/Ranking.hooks.ts
+++ b/src/components/Domain/Ranking/Ranking.hooks.ts
@@ -1,0 +1,30 @@
+import { useNavigation } from "@/util/hooks/useNavigation";
+import { useCallback, useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { headerContentState } from '@/states/state.header';
+import {
+    RankingHeader,
+    RankingDescription,
+  } from '@/components/App/AppHeader/HeaderContent/HeaderContentImpls/RankingHeader';
+
+
+export const useSettingHeader = () => {
+    const [headerContent, setHeaderContent] = useRecoilState(headerContentState);
+
+    const initializeHeaderContent = useCallback(() => {
+        setHeaderContent({
+            title: RankingHeader,
+            description: RankingDescription,
+            backward: {
+                visible: false,
+                historyStack: [],
+            },
+        });
+    }, []);
+
+    useEffect(() => {
+        initializeHeaderContent();
+    }, []);
+
+
+}

--- a/src/components/Domain/Ranking/Ranking.styles.tsx
+++ b/src/components/Domain/Ranking/Ranking.styles.tsx
@@ -1,7 +1,21 @@
 import styled from "@emotion/styled";
 import { Flex } from '@/components/UI/FlexBox';
 
-export const Root = styled.div`
+export const Root = styled(Flex)`
     width: 100%;
     height: auto;
+
+    & h4{
+        font-size: ${({ theme }) => theme.size.font.sm};
+        color: ${({ theme }) => theme.color.text.g3};
+        font-weight: 500;
+        line-height: 140%;
+    }
+`;
+
+export const IconWrapper = styled.div`
+    width: auto;
+    height: auto;
+    padding-bottom: 3.0rem;
+    padding-top: 5.0rem;
 `;

--- a/src/components/Domain/Ranking/Ranking.styles.tsx
+++ b/src/components/Domain/Ranking/Ranking.styles.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { Flex } from '@/components/UI/FlexBox';
 
 export const Root = styled.div`
     width: 100%;

--- a/src/components/Domain/Ranking/Ranking.tsx
+++ b/src/components/Domain/Ranking/Ranking.tsx
@@ -9,17 +9,19 @@ export const Ranking = () => {
 
     const RankingResultRended = () => {
         return message.status === 'loading' ? (
-            <div>loading ranking</div>
+            <h4>loading ranking</h4>
         ) : message.status === 'error' ? (
-            <div>getting ranking has an error</div>
+            <h4>getting ranking has an error</h4>
         ) : (
-            <div>{message.data?.message}</div>
+            <h4>{message.data?.message}</h4>
         )
     }
       
     return(
-        <S.Root>
-            <SVGIcon name={'RankingPageIcon'} width={250} height={250} viewBox={'0 0 210 210'}></SVGIcon>
+        <S.Root flex={"columnCenter"}>
+            <S.IconWrapper>
+                <SVGIcon name={'RankingPageIcon'} width={250} height={250} viewBox={'0 0 210 210'}></SVGIcon>
+            </S.IconWrapper>
             <RankingResultRended />
         </S.Root>
     )

--- a/src/components/Domain/Ranking/Ranking.tsx
+++ b/src/components/Domain/Ranking/Ranking.tsx
@@ -1,12 +1,26 @@
 import React, { useCallback, useEffect } from "react";
 import * as S from './Ranking.styles'
 import { SVGIcon } from "@/components/UI/SVGIcon";
-import { useSettingHeader } from "./Ranking.hooks";
+import { useGetRankingQuery, useSettingHeader } from "./Ranking.hooks";
 
 export const Ranking = () => {
     useSettingHeader();
+    const message = useGetRankingQuery();
+
+    const RankingResultRended = () => {
+        return message.status === 'loading' ? (
+            <div>loading ranking</div>
+        ) : message.status === 'error' ? (
+            <div>getting ranking has an error</div>
+        ) : (
+            <div>{message.data?.message}</div>
+        )
+    }
       
     return(
-        <SVGIcon name={'RankingPageIcon'} width={250} height={250} viewBox={'0 0 210 210'}></SVGIcon>
+        <S.Root>
+            <SVGIcon name={'RankingPageIcon'} width={250} height={250} viewBox={'0 0 210 210'}></SVGIcon>
+            <RankingResultRended />
+        </S.Root>
     )
 };

--- a/src/components/Domain/Ranking/Ranking.tsx
+++ b/src/components/Domain/Ranking/Ranking.tsx
@@ -28,6 +28,6 @@ export const Ranking = () => {
 
       
     return(
-        <SVGIcon name={'RankingPageIcon'} width={250} height={250} viewBox={'0 0 250 250'}></SVGIcon>
+        <SVGIcon name={'RankingPageIcon'} width={250} height={250} viewBox={'0 0 210 210'}></SVGIcon>
     )
 };

--- a/src/components/Domain/Ranking/Ranking.tsx
+++ b/src/components/Domain/Ranking/Ranking.tsx
@@ -1,31 +1,10 @@
 import React, { useCallback, useEffect } from "react";
 import * as S from './Ranking.styles'
 import { SVGIcon } from "@/components/UI/SVGIcon";
-import {
-    RankingHeader,
-    RankingDescription,
-  } from '@/components/App/AppHeader/HeaderContent/HeaderContentImpls/RankingHeader';
-import { useRecoilState } from 'recoil';
-import { headerContentState } from '@/states/state.header';
+import { useSettingHeader } from "./Ranking.hooks";
 
 export const Ranking = () => {
-    const [headerContent, setHeaderContent] = useRecoilState(headerContentState);
-    
-    const initializeHeaderContent = useCallback(() => {
-        setHeaderContent({
-            title: RankingHeader,
-            description: RankingDescription,
-            backward: {
-                visible: false,
-                historyStack: [],
-            },
-        });
-    }, []);
-
-    useEffect(() => {
-        initializeHeaderContent();
-    }, []);
-
+    useSettingHeader();
       
     return(
         <SVGIcon name={'RankingPageIcon'} width={250} height={250} viewBox={'0 0 210 210'}></SVGIcon>

--- a/src/util/Api/apis/RankingControllerApi.ts
+++ b/src/util/Api/apis/RankingControllerApi.ts
@@ -28,6 +28,7 @@ import {
 export class RankingControllerApi extends runtime.BaseAPI {
 
     /**
+     * ranking을 받아오는 api
      */
     async getRankingRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<LectureRankingDtoResponse>> {
         const queryParameters: any = {};


### PR DESCRIPTION
[작업요약]
rankingpage 구현
ranking api call

[작업상세]
ranking page header 내용 관리
ranking page에 content로 들어갈 내용 api call 받아와서 status값에 따라 출력


![image](https://github.com/sanhak-chatgpt/learning-mate-frontend/assets/106497893/aedefcf4-5baa-4f7e-935e-0bbd452c0012)
