### PR TITLE
feat: icon을 하단 footer에 주입 + 클릭시 이동

### DIFF
--- a/src/components/App/AppFooter/FooterContent/FooterContent.tsx
+++ b/src/components/App/AppFooter/FooterContent/FooterContent.tsx
@@ -10,6 +10,7 @@ export type NavItemPath = `/${string}`;
 export type NavItem<TName = IconRegistryKey, TPath = NavItemPath> = { name: TName; path: TPath };
 export const NAV_ITEM_PRESET: Array<NavItem> = [
   { name: 'NavHomeIcon', path: '/' },
+  { name: 'RankingTrophy', path: '/ranking' },
   { name: 'NavSettingIcon', path: '/setting' },
 ];
 


### PR DESCRIPTION
[작업요약]
하단 footer에 아이콘 주입

코드가 너무 깔끔해서 할게 없네요 허허. map함수 쓰라는게 저렇게 쓰는거군요

![image](https://github.com/sanhak-chatgpt/learning-mate-frontend/assets/106497893/f9dac841-7362-4258-9fde-c6de3eaa0cfe)
ㅇ이건 랭킹페이지 들어왔을 때

![image](https://github.com/sanhak-chatgpt/learning-mate-frontend/assets/106497893/55043ff2-ebb8-4388-a33a-21e684b63647)
이건 다른 페이지 들어왔을 때